### PR TITLE
fix: chunk getLogs to 10-block batches for Alchemy free tier

### DIFF
--- a/src/__tests__/flow-tracker.test.ts
+++ b/src/__tests__/flow-tracker.test.ts
@@ -25,9 +25,17 @@ function makeTransferLog(
 }
 
 function createMockClient(logs: ReturnType<typeof makeTransferLog>[] = []): PublicClient {
+  let returned = false;
   return {
     getBlockNumber: vi.fn().mockResolvedValue(20000n),
-    getLogs: vi.fn().mockResolvedValue(logs),
+    // Return logs only on the first chunk call to avoid duplication
+    getLogs: vi.fn().mockImplementation(() => {
+      if (!returned) {
+        returned = true;
+        return Promise.resolve(logs);
+      }
+      return Promise.resolve([]);
+    }),
     readContract: vi.fn().mockImplementation(({ functionName }: { functionName: string }) => {
       if (functionName === 'decimals') return Promise.resolve(6);
       if (functionName === 'symbol') return Promise.resolve('USDC');
@@ -99,10 +107,10 @@ describe('Flow Tracker', () => {
     expect(result.blockRange.to).toBe(20000n);
   });
 
-  it('uses default 1000 blocks when not specified', async () => {
+  it('uses default 100 blocks when not specified', async () => {
     const client = createMockClient([]);
     const result = await getExchangeFlows(client, 'ethereum', { token: USDC_ADDR });
-    expect(result.blockRange.from).toBe(19000n);
+    expect(result.blockRange.from).toBe(19900n);
     expect(result.blockRange.to).toBe(20000n);
   });
 

--- a/src/exchanges/flow-tracker.ts
+++ b/src/exchanges/flow-tracker.ts
@@ -9,7 +9,9 @@ const TRANSFER_EVENT = parseAbiItem(
 );
 
 const MAX_BLOCKS = 5000;
-const DEFAULT_BLOCKS = 1000;
+const DEFAULT_BLOCKS = 100;
+// Alchemy free tier allows max 10 blocks per getLogs request
+const CHUNK_SIZE = 10;
 
 // Minimal ABI for decimals and symbol
 const ERC20_METADATA_ABI = [
@@ -65,6 +67,32 @@ async function getTokenMeta(
   return meta;
 }
 
+/**
+ * Fetch logs in chunks to work within RPC provider block range limits.
+ * Alchemy free tier limits eth_getLogs to 10 blocks per request.
+ */
+async function getLogsChunked(
+  client: PublicClient,
+  tokenAddress: `0x${string}`,
+  fromBlock: bigint,
+  toBlock: bigint,
+) {
+  const allLogs: Awaited<ReturnType<typeof client.getLogs<typeof TRANSFER_EVENT>>> = [];
+
+  for (let start = fromBlock; start <= toBlock; start += BigInt(CHUNK_SIZE)) {
+    const end = start + BigInt(CHUNK_SIZE) - 1n > toBlock ? toBlock : start + BigInt(CHUNK_SIZE) - 1n;
+    const logs = await client.getLogs({
+      event: TRANSFER_EVENT,
+      address: tokenAddress,
+      fromBlock: start,
+      toBlock: end,
+    });
+    allLogs.push(...logs);
+  }
+
+  return allLogs;
+}
+
 export interface ExchangeFlowOptions {
   token?: `0x${string}`;
   exchange?: string;
@@ -111,16 +139,12 @@ export async function getExchangeFlows(
   >();
 
   for (const tokenAddress of tokenAddresses) {
+    const sym = knownSymbolMap.get(tokenAddress.toLowerCase()) ?? tokenAddress;
     let logs;
     try {
-      logs = await client.getLogs({
-        event: TRANSFER_EVENT,
-        address: tokenAddress,
-        fromBlock,
-        toBlock: latestBlock,
-      });
+      logs = await getLogsChunked(client, tokenAddress, fromBlock, latestBlock);
+      console.error(`[${chain}] ${sym}: ${logs.length} transfer logs in ${blocks} blocks`);
     } catch (err) {
-      const sym = knownSymbolMap.get(tokenAddress.toLowerCase()) ?? tokenAddress;
       console.error(`[${chain}] getLogs failed for ${sym}: ${err instanceof Error ? err.message : String(err)}`);
       continue;
     }
@@ -200,7 +224,6 @@ export async function getExchangeFlows(
     const inflow = formatUnits(entry.inflow, entry.decimals);
     const outflow = formatUnits(entry.outflow, entry.decimals);
     const net = entry.inflow - entry.outflow;
-    const netFlow = (net < 0n ? '-' : '') + formatUnits(net < 0n ? -net : net, entry.decimals);
 
     flows.push({
       exchange: entry.exchange,

--- a/src/report/daily-report.ts
+++ b/src/report/daily-report.ts
@@ -3,7 +3,7 @@ import { getClient, KNOWN_TOKENS } from '../chains/index.js';
 import { getExchangeFlows } from '../exchanges/index.js';
 import { getTokenPrices } from '../pricing/coingecko.js';
 import { getExchangeLookup } from '../exchanges/constants.js';
-import { formatUnits, parseAbiItem } from 'viem';
+import { formatUnits, parseAbiItem, type PublicClient } from 'viem';
 import { type Locale, t } from './i18n.js';
 
 const STABLECOINS = ['USDC', 'USDT', 'DAI', 'USDC.e', 'USDbC'];
@@ -13,6 +13,27 @@ const TRANSFER_EVENT = parseAbiItem(
 const ERC20_DECIMALS_ABI = [
   { name: 'decimals', type: 'function', stateMutability: 'view', inputs: [], outputs: [{ name: '', type: 'uint8' }] },
 ] as const;
+const LOG_CHUNK_SIZE = 10n;
+
+async function getLogsChunked(
+  client: PublicClient,
+  tokenAddress: `0x${string}`,
+  fromBlock: bigint,
+  toBlock: bigint,
+) {
+  const allLogs: Awaited<ReturnType<typeof client.getLogs<typeof TRANSFER_EVENT>>> = [];
+  for (let start = fromBlock; start <= toBlock; start += LOG_CHUNK_SIZE) {
+    const end = start + LOG_CHUNK_SIZE - 1n > toBlock ? toBlock : start + LOG_CHUNK_SIZE - 1n;
+    const logs = await client.getLogs({
+      event: TRANSFER_EVENT,
+      address: tokenAddress,
+      fromBlock: start,
+      toBlock: end,
+    });
+    allLogs.push(...logs);
+  }
+  return allLogs;
+}
 
 export async function generateDailyReport(
   config: DefiRadarConfig,
@@ -152,7 +173,7 @@ async function collectWhaleMovements(
 
       try {
         const latestBlock = await client.getBlockNumber();
-        const fromBlock = latestBlock - 200n;
+        const fromBlock = latestBlock - 100n;
 
         let decimals: number;
         try {
@@ -167,12 +188,8 @@ async function collectWhaleMovements(
         }
 
         const minTokenAmount = thresholdUsd / price;
-        const logs = await client.getLogs({
-          event: TRANSFER_EVENT,
-          address: tokenAddress as `0x${string}`,
-          fromBlock,
-          toBlock: latestBlock,
-        });
+        const logs = await getLogsChunked(client, tokenAddress as `0x${string}`, fromBlock, latestBlock);
+        console.error(`[${chainName}] whale scan ${symbol}: ${logs.length} logs in 100 blocks`);
 
         for (const log of logs) {
           const from = log.args.from;

--- a/src/tools/whale-movements.ts
+++ b/src/tools/whale-movements.ts
@@ -8,6 +8,27 @@ import { getTokenPrices } from '../pricing/coingecko.js';
 const TRANSFER_EVENT = parseAbiItem(
   'event Transfer(address indexed from, address indexed to, uint256 value)',
 );
+const LOG_CHUNK_SIZE = 10n;
+
+async function getLogsChunked(
+  client: PublicClient,
+  tokenAddress: `0x${string}`,
+  fromBlock: bigint,
+  toBlock: bigint,
+) {
+  const allLogs: Awaited<ReturnType<typeof client.getLogs<typeof TRANSFER_EVENT>>> = [];
+  for (let start = fromBlock; start <= toBlock; start += LOG_CHUNK_SIZE) {
+    const end = start + LOG_CHUNK_SIZE - 1n > toBlock ? toBlock : start + LOG_CHUNK_SIZE - 1n;
+    const logs = await client.getLogs({
+      event: TRANSFER_EVENT,
+      address: tokenAddress,
+      fromBlock: start,
+      toBlock: end,
+    });
+    allLogs.push(...logs);
+  }
+  return allLogs;
+}
 
 const ERC20_METADATA_ABI = [
   {
@@ -19,8 +40,8 @@ const ERC20_METADATA_ABI = [
   },
 ] as const;
 
-const MAX_BLOCKS = 2000;
-const DEFAULT_BLOCKS = 500;
+const MAX_BLOCKS = 500;
+const DEFAULT_BLOCKS = 100;
 
 export async function getWhaleMovementsTool(
   config: DefiRadarConfig,
@@ -114,12 +135,7 @@ async function scanWhaleTransfers(
 
   let logs;
   try {
-    logs = await client.getLogs({
-      event: TRANSFER_EVENT,
-      address: tokenAddress,
-      fromBlock,
-      toBlock: latestBlock,
-    });
+    logs = await getLogsChunked(client, tokenAddress, fromBlock, latestBlock);
   } catch {
     return [];
   }


### PR DESCRIPTION
Alchemy free plan limits eth_getLogs to 10 blocks per request. Split all getLogs calls into chunked batches and reduce default scan ranges to avoid rate limiting.